### PR TITLE
Character and content-length fixes

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -30,11 +30,12 @@ declare -i lines=$(wc -l < $playlist)
 declare -i songs=($lines-1)/2
 
 for ((song = 1; song <= $songs; song++)); do
-	songtitle="$(awk "NR==$song*2 {print}" $playlist | cut -d',' -f2)"
+	songtitle="$(awk "NR==$song*2 {print}" $playlist | cut -d',' -f2-)"
+	songtitle=${songtitle//\//-}
 	echo -e "$song/$songs\tDownloading $songtitle"
 	
 	songlink="$(awk "NR==$song*2+1 {print}" $playlist)"
-	curl -o "$outputdir/$song $songtitle.mp3" -s $songlink
+	curl -o "$outputdir/$song $songtitle.mp3" -s $songlink --ignore-content-length
 done
 
 echo -e "\nAll songs downloaded."


### PR DESCRIPTION
Added support for "complex" artist and track names that have characters which will cause issues, in addition to the occasional invalid `content-length` in header

1. Changed `songtitle` variable to include all commas in song name or title.  Example fix: `Earth, Wind & Fire - September.mp3` came up as `Earth.mp3`
2. Remove `/` and replace `-` when it exists in artists or track names because most OS does not support a file name with a slash. Example: `AC/DC - You Shook Me All Night Long` track name would cause script to error out because of the `/`. Change filename to `AC-DC - You Shook Me All Night Long`
3. For an unknown reason, some content-length set in the header was not correct and cURL would bomb out. Chose to `--ignore-content-length` in cURL, which will download the file correctly. 